### PR TITLE
TWH67 add open now text to open libraries, add span tags with classes for CSS styling results

### DIFF
--- a/app/schemas/libcal_times_dictionary.json
+++ b/app/schemas/libcal_times_dictionary.json
@@ -1,11 +1,18 @@
 {
 	"exact_matches": [
-		"Open 24 Hours"
+		{
+			"match_string": "Open 24 Hours",
+			"is_open": true
+		},
+		{
+			"match_string": "Closed",
+			"is_open": false
+		}
 	],
-	"regexes": [
+	"regex_matches": [
 		{
 			"example": "Open from 10:00am to 4:00pm",
-			"regular_expression": "((1[0-2]|0?[1-9]):([0-5][0-9]) ?([AaPp][Mm]))",
+			"regex_match": "((1[0-2]|0?[1-9]):([0-5][0-9]) ?([AaPp][Mm]))",
 			"intended_results": 2
 		}
 	]

--- a/app/schemas/libcal_times_dictionary.json
+++ b/app/schemas/libcal_times_dictionary.json
@@ -1,0 +1,12 @@
+{
+	"exact_matches": [
+		"Open 24 Hours"
+	],
+	"regexes": [
+		{
+			"example": "Open from 10:00am to 4:00pm",
+			"regular_expression": "((1[0-2]|0?[1-9]):([0-5][0-9]) ?([AaPp][Mm]))",
+			"intended_results": 2
+		}
+	]
+}

--- a/app/utils/libcalutils.py
+++ b/app/utils/libcalutils.py
@@ -94,3 +94,10 @@ class LibCalUtils():
             response = await client.post(settings.libcal_token_api_route, content=post_body, headers={"Content-Type": "application/json"})
         access_token = response.json().get('access_token')
         return access_token
+    
+    async def is_open_now(self, library_hours):
+        # Takes a library hours string and returns True if the library is currently open, False otherwise
+        # We can assume that all times and libraries use EST, TODO: we currently do not account for users in different timezones
+        libcal_times_dictionary = await self.file_utils.open_json_file('app/schemas/libcal_times_dictionary.json')
+        print(libcal_times_dictionary)
+        return True

--- a/app/utils/libcalutils.py
+++ b/app/utils/libcalutils.py
@@ -1,10 +1,12 @@
-import os
+import os, re
 import asyncio
 from datetime import datetime
 from app.config import settings
 import httpx
 import json
 
+import pytz
+from pytz import timezone
 from .file import FileUtils
 
 class LibCalUtils():
@@ -99,5 +101,34 @@ class LibCalUtils():
         # Takes a library hours string and returns True if the library is currently open, False otherwise
         # We can assume that all times and libraries use EST, TODO: we currently do not account for users in different timezones
         libcal_times_dictionary = await self.file_utils.open_json_file('app/schemas/libcal_times_dictionary.json')
-        print(libcal_times_dictionary)
-        return True
+        # First check for exact matches
+        for match_object in libcal_times_dictionary['exact_matches']:
+            if library_hours == match_object['match_string']:
+                return match_object['is_open']
+        
+        # Then check for regex matches that pull out library hours from the hours string
+        for regex_object in libcal_times_dictionary['regex_matches']:
+            regex_match = regex_object['regex_match']
+            results = re.findall(regex_match, library_hours)
+            library_hours = []
+            for result in results:
+                time = result[0][:-2]
+                period = result[0][-2:]
+                hours, minutes = time.split(":")
+                current_date = datetime.now().date()
+
+                eastern = timezone('US/Eastern')
+
+                if period == "am":
+                    datetime_obj = datetime(current_date.year, current_date.month, current_date.day, int(hours), int(minutes)).replace(tzinfo=eastern)
+                else:
+                    datetime_obj = datetime(current_date.year, current_date.month, current_date.day, int(hours)%12 + 12, int(minutes)).replace(tzinfo=eastern)
+
+                library_hours.append(datetime_obj)
+
+        now = datetime.now(tz=pytz.timezone('US/Eastern'))
+
+        if len(library_hours) == 2 and library_hours[0] < now and library_hours[1] > now:
+            return True
+
+        return False

--- a/app/worker.py
+++ b/app/worker.py
@@ -139,11 +139,11 @@ class LLMWorker():
             for library_code in reduced_results:
                 for library in json.loads(libraries):
                     if library["Library Code"] == library_code:
-                        response += library["Display name in Primo API"] + "\n"
+                        response += "<span class='library_title'>" + library["Display name in Primo API"] + "</span>" + "\n"
                         break
 
                 if library_hours is not None and library_code in library_hours:
-                        response += library_hours[library_code]
+                        response += "<span class='library_hours'>" + library_hours[library_code] + "</span>"
                         open = await self.is_open_now(library_hours[library_code])
                         if open:
                             response += " <span class='open_now'>(OPEN NOW)</span>"
@@ -152,7 +152,12 @@ class LLMWorker():
                     response += "Operating Hours unknown, please check library website\n"
 
                 counter = 1
+                start_book_list = True
                 for book in reduced_results[library_code]:
+                    if start_book_list:
+                        response += "<span class='book_list'>"
+                        start_book_list = False
+
                     response += str(counter) + ". " + book.get('title')
                     if 'author' in book:
                         response += " / " + ', '.join(book.get('author'))
@@ -169,7 +174,7 @@ class LLMWorker():
                         response += "   " + callNumber
                     response += "\n"
                     counter += 1
-                response += "\n"
+                response += "</span>\n"
             # TODO: Create a hollis link for the search results (instead of a link to the primo api)
             # TODO: Display the link as clickable in the react app (it just displays the plain text right now)
             response += "<a href='{}' target='_blank'>Click here to view the full search results in HOLLIS</a>".format(self.hollis_api_request)

--- a/app/worker.py
+++ b/app/worker.py
@@ -143,7 +143,11 @@ class LLMWorker():
                         break
 
                 if library_hours is not None and library_code in library_hours:
-                        response += library_hours[library_code] + "\n"
+                        response += library_hours[library_code]
+                        open = await self.is_open_now(library_hours[library_code])
+                        if open:
+                            response += " <span class='open_now'>(OPEN NOW)</span>"
+                        response += "\n"
                 else:
                     response += "Operating Hours unknown, please check library website\n"
 
@@ -186,3 +190,7 @@ class LLMWorker():
     async def get_library_hours(self):
         libcal_utils = LibCalUtils()
         return await LibCalUtils.get_library_hours(libcal_utils)
+    
+    async def is_open_now(self, library_hours):
+        libcal_utils = LibCalUtils()
+        return await libcal_utils.is_open_now(library_hours)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ distro==1.8.0
 exceptiongroup==1.1.3
 fastapi==0.104.1
 filelock==3.13.1
+freezegun==1.4.0
 frozenlist==1.4.0
 fsspec==2023.10.0
 greenlet==3.0.1

--- a/tests/test_libcal_utils.py
+++ b/tests/test_libcal_utils.py
@@ -1,0 +1,52 @@
+import pytest
+from datetime import datetime
+
+from freezegun import freeze_time
+# freeze time is using UTC, while the application is receiving library hours in UTC, so there will be descrepancies between
+# the hours string sent to is_open_now and the time that is being frozen
+
+from app.utils.libcalutils import LibCalUtils
+
+@pytest.mark.asyncio
+@freeze_time("2012-01-14")
+async def test_is_open_now_unknown_time_string():
+	libcal_utils = LibCalUtils()
+	result = await libcal_utils.is_open_now("nonsense_words")
+	print(result)
+	assert result == False
+	assert datetime.now() == datetime(2012, 1, 14)
+
+@pytest.mark.asyncio
+@freeze_time("2024-01-01 20:00:01") # 8:00pm UTC -> 3:00pm EST
+async def test_is_open_now_open_library():
+	libcal_utils = LibCalUtils()
+	result = await libcal_utils.is_open_now("Open from 10:00am to 4:00pm")
+	assert result == True
+
+@pytest.mark.asyncio
+@freeze_time("2024-01-01 10:00:01") # 10:00am UTC -> 5:00am EST
+async def test_is_open_now_closed_library_before_hours():
+	libcal_utils = LibCalUtils()
+	result = await libcal_utils.is_open_now("Open from 10:00am to 4:00pm")
+	assert result == False
+
+@pytest.mark.asyncio
+@freeze_time("2024-01-01 23:00:01") # 23:00am UTC -> 5:00pm EST
+async def test_is_open_now_closed_library_after_hours():
+	libcal_utils = LibCalUtils()
+	result = await libcal_utils.is_open_now("Open from 10:00am to 4:00pm")
+	assert result == False
+
+@pytest.mark.asyncio
+@freeze_time("2024-01-01 20:00:01") # 8:00pm UTC -> 3:00pm EST
+async def test_is_open_now_closed_library_after_hours():
+	libcal_utils = LibCalUtils()
+	result = await libcal_utils.is_open_now("Closed")
+	assert result == False
+
+@pytest.mark.asyncio
+@freeze_time("2024-01-01 20:00:01") # 8:00pm UTC -> 3:00pm EST
+async def test_is_open_now_closed_library_after_hours():
+	libcal_utils = LibCalUtils()
+	result = await libcal_utils.is_open_now("Open 24 Hours")
+	assert result == True


### PR DESCRIPTION
**TWH67, 73 add open now text to open libraries, add span tags with classes for CSS styling results**
* * *

**JIRA Ticket**:
https://at-harvard.atlassian.net/browse/TWH-67
https://at-harvard.atlassian.net/browse/TWH-73

# What does this Pull Request do?
- Adds an OPEN NOW tag to libraries that are open now, decided by comparing library hours with current time. Contains a dictionary that different library hour formats can be listed in, since some libraries appear to do this a bit differently.
- Adds span tags around library title, library hours, and book lists for CSS styling to target later

# How should this be tested?
Interact with chat as usual.

# Test coverage
Unit tests cover OPEN NOW functionality

# Interested parties
@ktamaral 
